### PR TITLE
Add HasCallStack constraint to combinators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Hspec Megaparsec 1.1.0
+
+* Add HasCallStack constraint to combinators
+
 ## Hspec Megaparsec 1.0.0
 
 * To be used with Megaparsec 6.

--- a/Test/Hspec/Megaparsec.hs
+++ b/Test/Hspec/Megaparsec.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE ConstraintKinds     #-}
 
 module Test.Hspec.Megaparsec
   ( -- * Basic expectations
@@ -44,7 +45,12 @@ import Text.Megaparsec.Error.Builder
 --
 -- > parse letterChar "" "x" `shouldParse` 'x'
 
-shouldParse :: (Ord t, ShowToken t, ShowErrorComponent e, Eq a, Show a)
+shouldParse :: ( HasCallStack
+               , Ord t
+               , ShowToken t
+               , ShowErrorComponent e
+               , Eq a
+               , Show a )
   => Either (ParseError t e) a
      -- ^ Result of parsing as returned by function like 'parse'
   -> a                 -- ^ Desired result
@@ -60,7 +66,11 @@ r `shouldParse` v = case r of
 --
 -- > parse (many punctuationChar) "" "?!!" `parseSatisfies` ((== 3) . length)
 
-parseSatisfies :: (Ord t, ShowToken t, ShowErrorComponent e, Show a)
+parseSatisfies :: ( HasCallStack
+                  , Ord t
+                  , ShowToken t
+                  , ShowErrorComponent e
+                  , Show a )
   => Either (ParseError t e) a
      -- ^ Result of parsing as returned by function like 'parse'
   -> (a -> Bool)       -- ^ Predicate
@@ -76,7 +86,7 @@ r `parseSatisfies` p = case r of
 --
 -- > parse (char 'x') "" `shouldFailOn` "a"
 
-shouldFailOn :: Show a
+shouldFailOn :: (HasCallStack, Show a)
   => (s -> Either (ParseError t e) a)
      -- ^ Parser that takes stream and produces result or error message
   -> s                 -- ^ Input that the parser should fail on
@@ -87,7 +97,11 @@ p `shouldFailOn` s = shouldFail (p s)
 --
 -- > parse (char 'x') "" `shouldSucceedOn` "x"
 
-shouldSucceedOn :: (Ord t, ShowToken t, ShowErrorComponent e, Show a)
+shouldSucceedOn :: ( HasCallStack
+                   , Ord t
+                   , ShowToken t
+                   , ShowErrorComponent e
+                   , Show a )
   => (s -> Either (ParseError t e) a)
      -- ^ Parser that takes stream and produces result or error message
   -> s                 -- ^ Input that the parser should succeed on
@@ -103,7 +117,11 @@ p `shouldSucceedOn` s = shouldSucceed (p s)
 --
 -- > parse (char 'x') "" "b" `shouldFailWith` err posI (utok 'b' <> etok 'x')
 
-shouldFailWith :: (Ord t, ShowToken t, ShowErrorComponent e, Show a)
+shouldFailWith :: ( HasCallStack
+                  , Ord t
+                  , ShowToken t
+                  , ShowErrorComponent e
+                  , Show a )
   => Either (ParseError t e) a
   -> ParseError t e
   -> Expectation
@@ -126,7 +144,11 @@ r `shouldFailWith` e = case r of
 --
 -- See also: 'initialState'.
 
-failsLeaving :: (Show a, Eq s, Show s, Stream s)
+failsLeaving :: ( HasCallStack
+                , Show a
+                , Eq s
+                , Show s
+                , Stream s )
   => (State s, Either (ParseError (Token s) e) a)
      -- ^ Parser that takes stream and produces result along with actual
      -- state information
@@ -144,7 +166,8 @@ failsLeaving :: (Show a, Eq s, Show s, Stream s)
 --
 -- See also: 'initialState'.
 
-succeedsLeaving :: ( ShowToken (Token s)
+succeedsLeaving :: ( HasCallStack
+                   , ShowToken (Token s)
                    , ShowErrorComponent e
                    , Show a
                    , Eq s
@@ -176,7 +199,7 @@ initialState s = State
 
 -- | Expectation that argument is result of a failed parser.
 
-shouldFail :: Show a
+shouldFail :: (HasCallStack, Show a)
   => Either (ParseError t e) a
   -> Expectation
 shouldFail r = case r of
@@ -186,7 +209,11 @@ shouldFail r = case r of
 
 -- | Expectation that argument is result of a succeeded parser.
 
-shouldSucceed :: (Ord t, ShowToken t, ShowErrorComponent e, Show a)
+shouldSucceed :: ( HasCallStack
+                 , Ord t
+                 , ShowToken t
+                 , ShowErrorComponent e
+                 , Show a )
   => Either (ParseError t e) a
   -> Expectation
 shouldSucceed r = case r of
@@ -197,7 +224,7 @@ shouldSucceed r = case r of
 
 -- | Compare two streams for equality and in the case of mismatch report it.
 
-checkUnconsumed :: (Eq s, Show s, Stream s)
+checkUnconsumed :: (HasCallStack, Eq s, Show s, Stream s)
   => s                 -- ^ Expected unconsumed input
   -> s                 -- ^ Actual unconsumed input
   -> Expectation

--- a/hspec-megaparsec.cabal
+++ b/hspec-megaparsec.cabal
@@ -23,7 +23,7 @@ flag dev
 library
   build-depends:      base               >= 4.7 && < 5.0
                     , containers         >= 0.5 && < 0.6
-                    , hspec-expectations >= 0.5 && < 0.9
+                    , hspec-expectations >= 0.8 && < 0.9
                     , megaparsec         >= 6.0 && < 7.0
   if !impl(ghc >= 7.8)
     build-depends:    tagged             == 0.8.*
@@ -52,7 +52,7 @@ test-suite tests
     ghc-options:      -Wall
   build-depends:      base               >= 4.7 && < 5.0
                     , hspec              >= 2.0 && < 3.0
-                    , hspec-expectations >= 0.5 && < 0.9
+                    , hspec-expectations >= 0.8 && < 0.9
                     , hspec-megaparsec
                     , megaparsec         >= 6.0 && < 7.0
   if !impl(ghc >= 7.8)


### PR DESCRIPTION
Without this, hspec reports Test/Hspec/Megaparsec.hs as source
location for failed tests instead of the actual call site.

The lower bound on hspec-expectations is raised to 0.8.0 which first
exports the HasCallStack constraint. This also needs ConstraintKinds.

fixes #5