### PR TITLE
Reuse hspec helpers for better output of failing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Adjusted `shouldParse` to use `shouldBe` from `hspec` under the hood to
+  take advantage of its pretty colorful error reporting.
+
 * Dropped support for GHC 8.0 and older.
 
 ## Hspec Megaparsec 2.0.0

--- a/Test/Hspec/Megaparsec.hs
+++ b/Test/Hspec/Megaparsec.hs
@@ -62,8 +62,7 @@ shouldParse
 r `shouldParse` v = case r of
   Left e -> expectationFailure $ "expected: " ++ show v ++
     "\nbut parsing failed with error:\n" ++ showBundle e
-  Right x -> unless (x == v) . expectationFailure $
-    "expected: " ++ show v ++ "\nbut got: " ++ show x
+  Right x -> x `shouldBe` v
 
 -- | Create an expectation by saying that the parser should successfully
 -- parse a value and that the value should satisfy some predicate.


### PR DESCRIPTION
This change allows for better diffing of the resulting values. Especially helpful with a big AST, where now it shows up as a big wall of red text.

See also https://www.bountysource.com/issues/44719070-how-to-show-diff-output